### PR TITLE
json2protobuf fails on oneof fields

### DIFF
--- a/src/protobuf2json.c
+++ b/src/protobuf2json.c
@@ -743,6 +743,10 @@ static int json2protobuf_process_message(
     void *protobuf_value = ((char *)*protobuf_message) + field_descriptor->offset;
     void *protobuf_value_quantifier = ((char *)*protobuf_message) + field_descriptor->quantifier_offset;
 
+    if (field_descriptor->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) {
+      *(uint32_t*)protobuf_value_quantifier = field_descriptor->id;
+    }
+
     if (field_descriptor->label == PROTOBUF_C_LABEL_REQUIRED) {
       result = json2protobuf_process_field(field_descriptor, json_object_value, protobuf_value, error_string, error_size);
       if (result) {
@@ -751,7 +755,8 @@ static int json2protobuf_process_message(
         return result;
       }
     } else if (field_descriptor->label == PROTOBUF_C_LABEL_OPTIONAL) {
-      if (field_descriptor->type == PROTOBUF_C_TYPE_MESSAGE || field_descriptor->type == PROTOBUF_C_TYPE_STRING) {
+      if (field_descriptor->type == PROTOBUF_C_TYPE_MESSAGE || field_descriptor->type == PROTOBUF_C_TYPE_STRING
+        || (field_descriptor->flags & PROTOBUF_C_FIELD_FLAG_ONEOF)) {
         // Do nothing
       } else {
         *(protobuf_c_boolean *)protobuf_value_quantifier = 1;

--- a/test/test-list.h
+++ b/test/test-list.h
@@ -60,6 +60,11 @@ TEST_DECLARE(reversible__default_values)
 TEST_DECLARE(reversible__numbers)
 TEST_DECLARE(reversible__strings)
 TEST_DECLARE(reversible__bytes)
+TEST_DECLARE(reversible__oneof_none)
+TEST_DECLARE(reversible__oneof_one)
+TEST_DECLARE(reversible__oneof_other)
+TEST_DECLARE(reversible__oneof_both_first)
+TEST_DECLARE(reversible__oneof_both_second)
 
 TASK_LIST_START
   TEST_ENTRY(protobuf2json_file__success)
@@ -116,4 +121,9 @@ TASK_LIST_START
   TEST_ENTRY(reversible__numbers)
   TEST_ENTRY(reversible__strings)
   TEST_ENTRY(reversible__bytes)
+  TEST_ENTRY(reversible__oneof_none)
+  TEST_ENTRY(reversible__oneof_one)
+  TEST_ENTRY(reversible__oneof_other)
+  TEST_ENTRY(reversible__oneof_both_first)
+  TEST_ENTRY(reversible__oneof_both_second)
 TASK_LIST_END

--- a/test/test-reversible.c
+++ b/test/test-reversible.c
@@ -419,3 +419,200 @@ TEST_IMPL(reversible__bytes) {
 
   RETURN_OK();
 }
+
+TEST_IMPL(reversible__oneof_none) {
+  int result;
+
+  const char *initial_json_string = \
+    "{}"
+  ;
+
+  ProtobufCMessage *protobuf_message;
+
+  result = json2protobuf_string((char *)initial_json_string, JSON_ALLOW_NUL, &foo__something__descriptor, &protobuf_message, NULL, 0);
+  ASSERT_ZERO(result);
+
+  Foo__Something *something = (Foo__Something *)protobuf_message;
+
+  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING__NOT_SET);
+  ASSERT(something->oneof_string == NULL);
+
+  char *json_string;
+  result = protobuf2json_string(protobuf_message, TEST_JSON_FLAGS, &json_string, NULL, 0);
+  ASSERT_ZERO(result);
+  ASSERT(json_string);
+
+  const char *expected_json_string = initial_json_string;
+
+  ASSERT_STRCMP(
+    json_string,
+    expected_json_string
+  );
+
+  protobuf_c_message_free_unpacked(protobuf_message, NULL);
+  free(json_string);
+
+  RETURN_OK();
+}
+
+TEST_IMPL(reversible__oneof_one) {
+  int result;
+
+  const char *initial_json_string = \
+    "{\n"
+    "  \"oneof_string\": \"hello\"\n"
+    "}"
+  ;
+
+  ProtobufCMessage *protobuf_message;
+
+  result = json2protobuf_string((char *)initial_json_string, JSON_ALLOW_NUL, &foo__something__descriptor, &protobuf_message, NULL, 0);
+  ASSERT_ZERO(result);
+
+  Foo__Something *something = (Foo__Something *)protobuf_message;
+
+  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_STRING);
+  ASSERT_STRCMP(something->oneof_string, "hello");
+
+  char *json_string;
+  result = protobuf2json_string(protobuf_message, TEST_JSON_FLAGS, &json_string, NULL, 0);
+  ASSERT_ZERO(result);
+  ASSERT(json_string);
+
+  const char *expected_json_string = initial_json_string;
+
+  ASSERT_STRCMP(
+    json_string,
+    expected_json_string
+  );
+
+  protobuf_c_message_free_unpacked(protobuf_message, NULL);
+  free(json_string);
+
+  RETURN_OK();
+}
+
+TEST_IMPL(reversible__oneof_other) {
+  int result;
+
+  const char *initial_json_string = \
+    "{\n"
+    "  \"oneof_bytes\": \"d29ybGQ=\"\n"
+    "}"
+  ;
+
+  ProtobufCMessage *protobuf_message;
+
+  result = json2protobuf_string((char *)initial_json_string, JSON_ALLOW_NUL, &foo__something__descriptor, &protobuf_message, NULL, 0);
+  ASSERT_ZERO(result);
+
+  Foo__Something *something = (Foo__Something *)protobuf_message;
+
+  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
+  ASSERT(something->oneof_bytes.len == 5);
+  ASSERT_STRCMP((const char*)something->oneof_bytes.data, "world");
+
+  char *json_string;
+  result = protobuf2json_string(protobuf_message, TEST_JSON_FLAGS, &json_string, NULL, 0);
+  ASSERT_ZERO(result);
+  ASSERT(json_string);
+
+  const char *expected_json_string = initial_json_string;
+
+  ASSERT_STRCMP(
+    json_string,
+    expected_json_string
+  );
+
+  protobuf_c_message_free_unpacked(protobuf_message, NULL);
+  free(json_string);
+
+  RETURN_OK();
+}
+
+TEST_IMPL(reversible__oneof_both_first) {
+  int result;
+
+  const char *initial_json_string = \
+    "{\n"
+    "  \"oneof_string\": \"hello\",\n"
+    "  \"oneof_bytes\": \"d29ybGQ=\"\n"
+    "}"
+  ;
+
+  ProtobufCMessage *protobuf_message;
+
+  result = json2protobuf_string((char *)initial_json_string, JSON_ALLOW_NUL, &foo__something__descriptor, &protobuf_message, NULL, 0);
+  ASSERT_ZERO(result);
+
+  Foo__Something *something = (Foo__Something *)protobuf_message;
+
+  // last input wins, irrespective of order in proto definition
+  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
+  ASSERT(something->oneof_bytes.len == 5);
+  ASSERT_STRCMP((const char*)something->oneof_bytes.data, "world");
+
+  char *json_string;
+  result = protobuf2json_string(protobuf_message, TEST_JSON_FLAGS, &json_string, NULL, 0);
+  ASSERT_ZERO(result);
+  ASSERT(json_string);
+
+  const char *expected_json_string = \
+    "{\n"
+    "  \"oneof_bytes\": \"d29ybGQ=\"\n"
+    "}"
+  ;
+
+  ASSERT_STRCMP(
+    json_string,
+    expected_json_string
+  );
+
+  protobuf_c_message_free_unpacked(protobuf_message, NULL);
+  free(json_string);
+
+  RETURN_OK();
+}
+
+TEST_IMPL(reversible__oneof_both_second) {
+  int result;
+
+  const char *initial_json_string = \
+    "{\n"
+    "  \"oneof_bytes\": \"d29ybGQ=\",\n"
+    "  \"oneof_string\": \"hello\"\n"
+    "}"
+  ;
+
+  ProtobufCMessage *protobuf_message;
+
+  result = json2protobuf_string((char *)initial_json_string, JSON_ALLOW_NUL, &foo__something__descriptor, &protobuf_message, NULL, 0);
+  ASSERT_ZERO(result);
+
+  Foo__Something *something = (Foo__Something *)protobuf_message;
+
+  // last input wins, irrespective of order in proto definition
+  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_STRING);
+  ASSERT_STRCMP(something->oneof_string, "hello");
+
+  char *json_string;
+  result = protobuf2json_string(protobuf_message, TEST_JSON_FLAGS, &json_string, NULL, 0);
+  ASSERT_ZERO(result);
+  ASSERT(json_string);
+
+  const char *expected_json_string = \
+    "{\n"
+    "  \"oneof_string\": \"hello\"\n"
+    "}"
+  ;
+
+  ASSERT_STRCMP(
+    json_string,
+    expected_json_string
+  );
+
+  protobuf_c_message_free_unpacked(protobuf_message, NULL);
+  free(json_string);
+
+  RETURN_OK();
+}

--- a/test/test-reversible.c
+++ b/test/test-reversible.c
@@ -531,6 +531,9 @@ TEST_IMPL(reversible__oneof_other) {
 }
 
 TEST_IMPL(reversible__oneof_both_first) {
+#if JANSSON_VERSION_HEX < 0x020800
+  RETURN_SKIP("behavior for multiple oneof values can only be guaranteed for Jansson >= 2.8");
+#else
   int result;
 
   const char *initial_json_string = \
@@ -572,9 +575,13 @@ TEST_IMPL(reversible__oneof_both_first) {
   free(json_string);
 
   RETURN_OK();
+#endif
 }
 
 TEST_IMPL(reversible__oneof_both_second) {
+#if JANSSON_VERSION_HEX < 0x020800
+  RETURN_SKIP("behavior for multiple oneof values can only be guaranteed for Jansson >= 2.8");
+#else
   int result;
 
   const char *initial_json_string = \
@@ -615,4 +622,5 @@ TEST_IMPL(reversible__oneof_both_second) {
   free(json_string);
 
   RETURN_OK();
+#endif
 }

--- a/test/test-reversible.c
+++ b/test/test-reversible.c
@@ -434,7 +434,7 @@ TEST_IMPL(reversible__oneof_none) {
 
   Foo__Something *something = (Foo__Something *)protobuf_message;
 
-  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING__NOT_SET);
+  ASSERT_EQUALS(something->something_case, FOO__SOMETHING__SOMETHING__NOT_SET);
   ASSERT(something->oneof_string == NULL);
 
   char *json_string;
@@ -471,7 +471,7 @@ TEST_IMPL(reversible__oneof_one) {
 
   Foo__Something *something = (Foo__Something *)protobuf_message;
 
-  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_STRING);
+  ASSERT_EQUALS(something->something_case, FOO__SOMETHING__SOMETHING_ONEOF_STRING);
   ASSERT_STRCMP(something->oneof_string, "hello");
 
   char *json_string;
@@ -508,8 +508,8 @@ TEST_IMPL(reversible__oneof_other) {
 
   Foo__Something *something = (Foo__Something *)protobuf_message;
 
-  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
-  ASSERT(something->oneof_bytes.len == 5);
+  ASSERT_EQUALS(something->something_case, FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
+  ASSERT_EQUALS((int)something->oneof_bytes.len, 5);
   ASSERT_STRCMP((const char*)something->oneof_bytes.data, "world");
 
   char *json_string;
@@ -548,8 +548,8 @@ TEST_IMPL(reversible__oneof_both_first) {
   Foo__Something *something = (Foo__Something *)protobuf_message;
 
   // last input wins, irrespective of order in proto definition
-  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
-  ASSERT(something->oneof_bytes.len == 5);
+  ASSERT_EQUALS(something->something_case, FOO__SOMETHING__SOMETHING_ONEOF_BYTES);
+  ASSERT_EQUALS((int)something->oneof_bytes.len, 5);
   ASSERT_STRCMP((const char*)something->oneof_bytes.data, "world");
 
   char *json_string;
@@ -592,7 +592,7 @@ TEST_IMPL(reversible__oneof_both_second) {
   Foo__Something *something = (Foo__Something *)protobuf_message;
 
   // last input wins, irrespective of order in proto definition
-  ASSERT(something->something_case == FOO__SOMETHING__SOMETHING_ONEOF_STRING);
+  ASSERT_EQUALS(something->something_case, FOO__SOMETHING__SOMETHING_ONEOF_STRING);
   ASSERT_STRCMP(something->oneof_string, "hello");
 
   char *json_string;


### PR DESCRIPTION
When decoding a message with oneof fields from JSON, the <field>_case member of the protobuf structure is not set, causing the field to appear to have no value even though a value was given in the JSON.

The attached commits add tests for oneof decoding (currently failing) and a fix (based on code by @dapaulid).