### PR TITLE
NULL repeated fields should be converted to an empty list

### DIFF
--- a/src/protobuf2json.c
+++ b/src/protobuf2json.c
@@ -258,15 +258,15 @@ static int protobuf2json_process_message(
     } else { // PROTOBUF_C_LABEL_REPEATED
       const size_t *protobuf_values_count = (const size_t *)protobuf_value_quantifier;
 
-      if (*protobuf_values_count) {
-        json_t *array = json_array();
-        if (!array) {
-          SET_ERROR_STRING_AND_RETURN(
-            PROTOBUF2JSON_ERR_CANNOT_ALLOCATE_MEMORY,
-            "Cannot allocate JSON structure using json_array()"
-          );
-        }
+      json_t *array = json_array();
+      if (!array) {
+        SET_ERROR_STRING_AND_RETURN(
+          PROTOBUF2JSON_ERR_CANNOT_ALLOCATE_MEMORY,
+          "Cannot allocate JSON structure using json_array()"
+        );
+      }
 
+      if (*protobuf_values_count) {
         size_t value_size = protobuf2json_value_size_by_type(field_descriptor->type);
         if (!value_size) {
           SET_ERROR_STRING_AND_RETURN(
@@ -294,13 +294,13 @@ static int protobuf2json_process_message(
             );
           }
         }
+      }
 
-        if (json_object_set_new(*json_message, field_descriptor->name, array)) {
-          SET_ERROR_STRING_AND_RETURN(
-            PROTOBUF2JSON_ERR_JANSSON_INTERNAL,
-            "Error in json_object_set_new()"
-          );
-        }
+      if (json_object_set_new(*json_message, field_descriptor->name, array)) {
+        SET_ERROR_STRING_AND_RETURN(
+          PROTOBUF2JSON_ERR_JANSSON_INTERNAL,
+          "Error in json_object_set_new()"
+        );
       }
     }
   }


### PR DESCRIPTION
According to the 'JSON Mapping' section in the proto3 Language guide
found here:

https://developers.google.com/protocol-buffers/docs/proto3#json

It is mentioned that NULL repeated fields should be converted to an
empty list.

Currently protobuf2json-c does not convert a NULL repeated field to
JSON (it simply ignores it). This patch updates the library to ensure
that NULL repeated fields are converted to empty JSON lists.